### PR TITLE
Modify functions and tests to support HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ Or even add your coworker's remote to work in some branch together:
 $ add-remote my-coworker
 
 $ git remote -v
-origin  git@github.com:caarlos0/random.git (fetch)
-origin  git@github.com:caarlos0/random.git (push)
-my-coworker  git@github.com:my-coworker/random.git (fetch)
-my-coworker  git@github.com:my-coworker/random.git (push)
+origin  https://github.com/caarlos0/random.git (fetch)
+origin  https://github.com/caarlos0/random.git (push)
+my-coworker  https://github.com/my-coworker/random.git (fetch)
+my-coworker  https://github.com/my-coworker/random.git (push)
 ```
 
 Some people have hard aliases in github, so you can even set the remote's name:

--- a/add-remote.sh
+++ b/add-remote.sh
@@ -9,7 +9,7 @@ __addremote_url() {
     return 1
   fi
   remote="$(git config --get remote.origin.url)"
-  current="$(echo "$remote" | sed -e 's/.*github.com\://' -e 's/\/.*//')"
+  current="$(echo "$remote" | sed -e 's/.*github\.com.//' -e 's/\/.*//')"
   echo "$remote" | sed -e "s/$current/$fork/"
 }
 

--- a/tests/helper.sh
+++ b/tests/helper.sh
@@ -1,9 +1,17 @@
 #!/bin/sh
-# setups a fake local repository
-fakerepo() {
+# setup a fake local repository with SSH protocol
+fakerepo_ssh() {
   cd "$(mktempdir)" || exit
   git init -q
   git remote add origin git@github.com:fake/fake.git
+  pwd
+}
+
+# setup a fake local repository with HTTPS protocol
+fakerepo_https() {
+  cd "$(mktempdir)" || exit
+  git init -q
+  git remote add origin https://github.com/fake/fake.git
   pwd
 }
 

--- a/tests/suite.clitest.md
+++ b/tests/suite.clitest.md
@@ -9,33 +9,63 @@ $ source tests/helper.sh
 $
 ```
 
-# add-upstream
+# add-upstream with ssh
 
 ```console
-$ cd "$(fakerepo)"
+$ cd "$(fakerepo_ssh)"
 $ add-upstream another-fake
 $ git config --get remote.upstream.url
 git@github.com:another-fake/fake.git
 $
 ```
 
-# add-remote with 2 args
+# add-upstream with https
 
 ```console
-$ cd "$(fakerepo)"
+$ cd "$(fakerepo_https)"
+$ add-upstream another-fake
+$ git config --get remote.upstream.url
+https://github.com/another-fake/fake.git
+$
+```
+
+# add-remote with ssh and 2 args
+
+```console
+$ cd "$(fakerepo_ssh)"
 $ add-remote fork becker
 $ git config --get remote.becker.url
 git@github.com:fork/fake.git
 $
 ```
 
-# add-remote with 1 arg
+# add-remote with with https and 2 args
 
 ```console
-$ cd "$(fakerepo)"
+$ cd "$(fakerepo_https)"
+$ add-remote fork becker
+$ git config --get remote.becker.url
+https://github.com/fork/fake.git
+$
+```
+
+# add-remote with ssh and 1 arg
+
+```console
+$ cd "$(fakerepo_ssh)"
 $ add-remote caarlos0
 $ git config --get remote.caarlos0.url
 git@github.com:caarlos0/fake.git
+$
+```
+
+# add-remote with https and 1 arg
+
+```console
+$ cd "$(fakerepo_https)"
+$ add-remote caarlos0
+$ git config --get remote.caarlos0.url
+https://github.com/caarlos0/fake.git
 $
 ```
 
@@ -44,16 +74,6 @@ $
 ```console
 $ cd "$(mktempdir)"
 $ add-remote whatever
-A remote called 'origin' doesn't exist. Aborting.
-$
-```
-
-# add-remote when folder is not git repository
-
-```console
-$ cd "$(fakerepo)"
-$ git remote remove origin
-$ add-remote ahoy
 A remote called 'origin' doesn't exist. Aborting.
 $
 ```
@@ -67,10 +87,40 @@ A remote called 'origin' doesn't exist. Aborting.
 $
 ```
 
-# add-upstream when folder is not git repository
+# add-remote when origin does not exist with ssh
 
 ```console
-$ cd "$(fakerepo)"
+$ cd "$(fakerepo_ssh)"
+$ git remote remove origin
+$ add-remote ahoy
+A remote called 'origin' doesn't exist. Aborting.
+$
+```
+
+# add-remote when origin does not exist with https
+
+```console
+$ cd "$(fakerepo_https)"
+$ git remote remove origin
+$ add-remote ahoy
+A remote called 'origin' doesn't exist. Aborting.
+$
+```
+
+# add-upstream when origin does not exist with ssh
+
+```console
+$ cd "$(fakerepo_ssh)"
+$ git remote remove origin
+$ add-upstream nope
+A remote called 'origin' doesn't exist. Aborting.
+$
+```
+
+# add-upstream when origin does not exist
+
+```console
+$ cd "$(fakerepo_https)"
 $ git remote remove origin
 $ add-upstream nope
 A remote called 'origin' doesn't exist. Aborting.


### PR DESCRIPTION
This PR extends the function to support HTTPS.

Currently, only `git@github.com:user/repo.git` remote URLs are supported.  If you attempt to use `add-remote` or `add-upstream` with a remote such as `https://github.com/user/repo.git`, the result is an invalid URL.

I also added tests and one example to the README for HTTPS.