### PR TITLE
Take into account url.<base>.insteadOf config

### DIFF
--- a/add-remote.sh
+++ b/add-remote.sh
@@ -8,7 +8,7 @@ __addremote_url() {
     echo "A remote called 'origin' doesn't exist. Aborting." >&2
     return 1
   fi
-  remote="$(git config --get remote.origin.url)"
+  remote="$(git ls-remote --get-url origin)"
   current="$(echo "$remote" | sed -e 's/.*github\.com.//' -e 's/\/.*//')"
   echo "$remote" | sed -e "s/$current/$fork/"
 }


### PR DESCRIPTION
Use git ls-remote --get-url <remote> which return the
url taking into account the url.<base>.insteadOf setting.

With this change, having:

[url "git@github.com:"]
      insteadOf = gh:

in ~/.gitconfig and running add-remote on a repository cloned with
git clone gh:caarlos0/git-add-remote works as expected.