### PR TITLE
Add Fig as an installation option in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,14 @@ If you use bash, you can clone this repo somewhere or just download the
 [add-remote.sh](/add-remote.sh) file and source the
 [add-remote.sh](/add-remote.sh) file in your `~/.profile` or wherever you like.
 
+## Fig
+
+[Fig](https://fig.io) adds apps, shortcuts, and autocomplete to your existing terminal.
+
+
+Install `git-add-remote` in just one click.
+
+<a href="https://fig.io/plugins/git-add-remote_caarlos0-graveyard" target="_blank"><img src="https://fig.io/badges/install-with-fig.svg" /></a>
 
 # `git alias`ing
 


### PR DESCRIPTION
The [Fig Plugin Store](https://fig.io/plugins) supports 1-click install for 400+ shell plugins. We have over 100k users, thousands of whom manage their shell configuration with Fig.

`git-add-remote` is already listed in the store so we'd love to have it listed as a download method on your readme.

Thanks so much and please let me know if you have any questions!